### PR TITLE
Add solutions to schedule

### DIFF
--- a/src/schedules/template.js
+++ b/src/schedules/template.js
@@ -29,7 +29,7 @@ const template = (w) =>
       w.week(1),
       w.thu(),
       w.welly(),
-      w.deploy('tdd-bowling-kata-solution', 'conways-solution-solution')
+      w.deploy('tdd-bowling-kata-solution', 'conways-solution')
     ),
     w.on(w.week(1), w.fri(), w.all(), w.deploy('ascii-art-reader')),
     w.on(w.week(1), w.fri(), w.welly(), w.deploy('ascii-art-reader-solution')),
@@ -46,7 +46,7 @@ const template = (w) =>
     w.on(w.week(2), w.wed(), w.welly(), w.deploy('pupparazzi-solution')),
     w.on(w.week(2), w.thu(), w.all(), w.deploy('heroku-checklist')),
     w.on(w.week(3), w.mon(), w.all(), w.deploy('knex-todo-cli')),
-    w.on(w.week(3), w.mon(), w.welly(), w.deploy('knex-todo-cli-stories')),
+    w.on(w.week(3), w.mon(), w.welly(), w.deploy('knex-todo-cli-solution')),
     w.on(w.week(3), w.tue(), w.all(), w.deploy('knex-joins-stories')),
     w.on(
       w.week(3),


### PR DESCRIPTION
The Wellington campus publishes their solutions on the same day as the
exercises. This means their default schedule now looks like this:

```javascript
// file generated by spork
module.exports = (on) => {
  // Cohort starting Thu Apr 28

  ...

  // week 1, day 4
  on('2022-05-01').deploy('tdd-bowling-kata', 'conways').to('testing-sosij')

  // week 1, day 4
  on('2022-05-01')
    .deploy('tdd-bowling-kata-solution', 'conways-solution-solution')
    .to('testing-sosij')

  ...
}
````