### PR TITLE
Add no-scss fullstacks and rearrange online wk6

### DIFF
--- a/src/schedules/template.js
+++ b/src/schedules/template.js
@@ -99,13 +99,13 @@ const template = (w) =>
     w.on(w.week(5), w.mon(), w.all(), w.deploy('charlottes-web-log-api')),
     w.on(w.week(5), w.tue(), w.all(), w.deploy('react-to-web-api')),
     w.on(w.week(5), w.wed(), w.all(), w.deploy('consuming-external-apis')),
-    w.on(w.week(6), w.mon(), w.all(), w.deploy('redux-minimal')), // TODO: change this to redux-zoo for Online
+    w.on(w.week(6), w.mon(), w.except(w.online()), w.deploy('redux-minimal')),
     w.on(w.week(6), w.mon(), w.welly(), w.deploy('redux-minimal-solution')),
     w.on(
       w.week(6),
       w.mon(),
       w.online(),
-      w.deploy('todo-full-stack', 'my-fullstack-collection', 'my-fullstack-collection-scss', 'boilerplate-fullstack', 'boilerplate-fullstack-scss')
+      w.deploy('redux-zoo', 'todo-full-stack', 'my-fullstack-collection', 'my-fullstack-collection-scss', 'boilerplate-fullstack', 'boilerplate-fullstack-scss')
     ),
     w.on(w.week(6), w.tue(), w.except(w.online()), w.deploy('sweet-as-beers')),
     w.on(w.week(6), w.tue(), w.welly(), w.deploy('sweet-as-beers-solution')),


### PR DESCRIPTION
For all campuses, spork boilerplate-fullstack and boilerplate-fullstack-scss together, plus my-fullstack-collection and my-fullstack-collection-scss together. Also bring these (and todo-fullstack) earlier in Week 6 for Online, so that students can use them as a base for personal projects if they haven't started coding yet (this only applies to Online, because we're doing personal project presentations on Monday of week 7 now). 
** Also add redux-zoo for online. This hasn't been added to the challenges repo yet, but I will add it before week 6 rolls around. I want to get redux-zoo into spork before we build the spork schedules for Manaia and Pikopiko. 