### PR TITLE
spork updates for React boilerplates

### DIFF
--- a/src/schedules/template.js
+++ b/src/schedules/template.js
@@ -70,10 +70,11 @@ const template = (w) =>
       w.deploy('broken-kaleidoscope', 'memory', 'enspiraled')
     ),
     w.on(w.week(4), w.wed(), w.all(), w.deploy('worldwide-routing')),
-    w.on(w.week(4), w.thu(), w.all(), w.deploy('boilerplate-react-webpack')),
+    w.on(w.week(4), w.thu(), w.all(), w.deploy('boilerplate-react')),
     w.on(w.week(5), w.mon(), w.all(), w.deploy('charlottes-web-log-api')),
     w.on(w.week(5), w.tue(), w.all(), w.deploy('react-to-web-api')),
     w.on(w.week(5), w.wed(), w.all(), w.deploy('consuming-external-apis')),
+    w.on(w.week(5), w.thu(), w.all(), w.deploy('boilerplate-react-api')),
     w.on(w.week(6), w.mon(), w.except(w.online()), w.deploy('redux-minimal')),
     w.on(
       w.week(6),


### PR DESCRIPTION
Kelly and Emily have made and added a new `boilerplate-react` repo in `challenges`, and this PR's buddy PR (in the `challenges` repo) renames `boilerplate-react-webpack` as `boilerplate-react-api`. 

This PR sets up `boilerplate-react` to deploy for all campuses in week 4, and `boilerplate-react-api` for all campuses in week 5. 

I've deliberately held back this PR until after Thursday of week 5, so that it doesn't affect sporking for the current cohorts. But it should be fine to merge it now, touch wood. 